### PR TITLE
[WIP] Fix package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "autocomplete-css",
+  "name": "autocomplete-swift",
   "version": "0.11.0",
   "description": "CSS property name and value autocompletions",
   "main": "./lib/main",


### PR DESCRIPTION
This allows users to clone the repo and run `apm link` without it conflicting with `autocomplete-css`.

@jpsim I've marked this as WIP since other changes could be made to other fields in `package.json` and the README, but wanted to get your input on that.
